### PR TITLE
Remove workaround related to missing device alias field in Domain xml

### DIFF
--- a/pkg/network/setup/netstat.go
+++ b/pkg/network/setup/netstat.go
@@ -213,18 +213,8 @@ func ifacesStatusFromDomainInterfaces(domainSpecIfaces []api.Interface) []v1.Vir
 	var vmiStatusIfaces []v1.VirtualMachineInstanceNetworkInterface
 
 	for _, domainSpecIface := range domainSpecIfaces {
-		var ifaceAlias string
-		if domainSpecIface.Alias == nil {
-			// TODO Hermes
-			// Alias is not being persisted in Domain XML
-			// Bug to track https://dev.azure.com/mariner-org/ECF/_queries/edit/4785/?triage=true
-			ifaceAlias = "default"
-		} else {
-			ifaceAlias = domainSpecIface.Alias.GetName()
-		}
-
 		vmiStatusIfaces = append(vmiStatusIfaces, v1.VirtualMachineInstanceNetworkInterface{
-			Name:       ifaceAlias,
+			Name:       domainSpecIface.Alias.GetName(),
 			MAC:        domainSpecIface.MAC.MAC,
 			InfoSource: netvmispec.InfoSourceDomain,
 			QueueCount: domainInterfaceQueues(domainSpecIface.Driver),

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1030,12 +1030,7 @@ func (d *VirtualMachineController) updateVolumeStatusesFromDomain(vmi *v1.Virtua
 	if len(vmi.Status.VolumeStatus) > 0 {
 		diskDeviceMap := make(map[string]string)
 		for _, disk := range domain.Spec.Devices.Disks {
-			// TODO Hermes. Following rootfs is added as a hacky fix till bug https://microsoft.visualstudio.com/OS/_workitems/edit/44268746 is not fixed
-			if strings.Contains(disk.Source.File, "rootfs") {
-				diskDeviceMap["rootfs"] = disk.Target.Device
-			}
-			// TODO Hermes. CH-enabled libvirt removes disk alias, even though the alias is present in the XML genererated by virt-launcher. Thus we're not using target device to uniquely identify the disk.
-			// diskDeviceMap[disk.Alias.GetName()] = disk.Target.Device
+			diskDeviceMap[disk.Alias.GetName()] = disk.Target.Device
 		}
 		specVolumeMap := make(map[string]v1.Volume)
 		for _, volume := range vmi.Spec.Volumes {

--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -374,15 +374,7 @@ func (l *LibvirtConnection) GetDeviceAliasMap(domain *libvirt.Domain) (map[strin
 	}
 
 	for _, iface := range domSpec.Devices.Interfaces {
-		var ifaceAlias string
-		if iface.Alias == nil {
-			// TODO Hermes Alias is not being persisted in Domain XML
-			// Bug to track https://dev.azure.com/mariner-org/ECF/_queries/edit/4785/?triage=true
-			ifaceAlias = "default"
-		} else {
-			ifaceAlias = iface.Alias.GetName()
-		}
-		devAliasMap[iface.Target.Device] = ifaceAlias
+		devAliasMap[iface.Target.Device] = iface.Alias.GetName()
 	}
 
 	for _, disk := range domSpec.Devices.Disks {

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -2028,18 +2028,7 @@ func (l *LibvirtDomainManager) buildDevicesMetadata(vmi *v1.VirtualMachineInstan
 	devices := domainSpec.Devices
 	interfaces := devices.Interfaces
 	for _, nic := range interfaces {
-
-		// Remove leading + signs from below lines
-		var ifaceAlias string
-		if nic.Alias == nil {
-			// TODO Hermes Alias is not being persisted in Domain XML
-			// Bug to track https://dev.azure.com/mariner-org/ECF/_queries/edit/4785/?triage=true
-			ifaceAlias = "default"
-		} else {
-			ifaceAlias = nic.Alias.GetName()
-		}
-
-		if data, exist := taggedInterfaces[ifaceAlias]; exist {
+		if data, exist := taggedInterfaces[nic.Alias.GetName()]; exist {
 			var mac string
 			if nic.MAC != nil {
 				mac = nic.MAC.MAC


### PR DESCRIPTION
### What this PR does
Before this PR: Due to a limitation in Cloud-Hypervisor driver of Libvirt, the device alias field in domain XML were not persisted by Libvirt. This meant that even though virt-launcher supplied an alias for each device to Libvirt in the initial domain creation request, they would be dropped by Libvirt. More details: https://dev.azure.com/mariner-org/ECF/_workitems/edit/4785/
KubeVirt relies on the alias field to identify devices, and their absence led to exceptions. The workaround was to return hardcoded well-known alias values wherever the device alias was queried.

After this PR:

LibVirt's CH-driver persists the device alias, so KubeVirt can directly query the device alias.

Pipeline to verify changes: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=764896&view=results
