### PR TITLE
Add missing Hypervisor field in test VMs

### DIFF
--- a/tests/instancetype/instancetype.go
+++ b/tests/instancetype/instancetype.go
@@ -1480,7 +1480,8 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						},
 						Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 							Spec: virtv1.VirtualMachineInstanceSpec{
-								Domain: virtv1.DomainSpec{},
+								Hypervisor: "ch",
+								Domain:     virtv1.DomainSpec{},
 							},
 						},
 					},
@@ -1523,7 +1524,8 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						},
 						Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 							Spec: virtv1.VirtualMachineInstanceSpec{
-								Domain: virtv1.DomainSpec{},
+								Hypervisor: "ch",
+								Domain:     virtv1.DomainSpec{},
 							},
 						},
 					},
@@ -1554,6 +1556,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						},
 						Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 							Spec: virtv1.VirtualMachineInstanceSpec{
+								Hypervisor: "ch",
 								Domain: virtv1.DomainSpec{
 									CPU: &virtv1.CPU{
 										Cores:   uint32(1),
@@ -1594,6 +1597,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						},
 						Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 							Spec: virtv1.VirtualMachineInstanceSpec{
+								Hypervisor: "ch",
 								Domain: virtv1.DomainSpec{
 									CPU: &virtv1.CPU{
 										Cores:   uint32(2),
@@ -1631,7 +1635,8 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						},
 						Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 							Spec: virtv1.VirtualMachineInstanceSpec{
-								Domain: virtv1.DomainSpec{},
+								Hypervisor: "ch",
+								Domain:     virtv1.DomainSpec{},
 							},
 						},
 					},
@@ -1665,6 +1670,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						},
 						Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 							Spec: virtv1.VirtualMachineInstanceSpec{
+								Hypervisor: "ch",
 								Domain: virtv1.DomainSpec{
 									CPU: &virtv1.CPU{
 										Cores:   uint32(1),
@@ -1705,6 +1711,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						},
 						Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 							Spec: virtv1.VirtualMachineInstanceSpec{
+								Hypervisor: "ch",
 								Domain: virtv1.DomainSpec{
 									CPU: &virtv1.CPU{
 										Cores:   uint32(2),
@@ -1742,6 +1749,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						},
 						Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 							Spec: virtv1.VirtualMachineInstanceSpec{
+								Hypervisor: "ch",
 								Domain: virtv1.DomainSpec{
 									Memory: &virtv1.Memory{
 										Guest: resource.NewQuantity(2*1024*1024*1024, resource.BinarySI),
@@ -1808,7 +1816,8 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						},
 						Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 							Spec: virtv1.VirtualMachineInstanceSpec{
-								Domain: virtv1.DomainSpec{},
+								Hypervisor: "ch",
+								Domain:     virtv1.DomainSpec{},
 							},
 						},
 					},
@@ -1852,7 +1861,8 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						},
 						Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 							Spec: virtv1.VirtualMachineInstanceSpec{
-								Domain: virtv1.DomainSpec{},
+								Hypervisor: "ch",
+								Domain:     virtv1.DomainSpec{},
 							},
 						},
 					},
@@ -1884,6 +1894,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						},
 						Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 							Spec: virtv1.VirtualMachineInstanceSpec{
+								Hypervisor: "ch",
 								Domain: virtv1.DomainSpec{
 									CPU: &virtv1.CPU{
 										Cores:   uint32(1),
@@ -1925,6 +1936,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						},
 						Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 							Spec: virtv1.VirtualMachineInstanceSpec{
+								Hypervisor: "ch",
 								Domain: virtv1.DomainSpec{
 									CPU: &virtv1.CPU{
 										Cores:   uint32(1),
@@ -1966,6 +1978,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						},
 						Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 							Spec: virtv1.VirtualMachineInstanceSpec{
+								Hypervisor: "ch",
 								Domain: virtv1.DomainSpec{
 									CPU: &virtv1.CPU{
 										Cores:   uint32(1),
@@ -2007,6 +2020,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						},
 						Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 							Spec: virtv1.VirtualMachineInstanceSpec{
+								Hypervisor: "ch",
 								Domain: virtv1.DomainSpec{
 									CPU: &virtv1.CPU{
 										Cores:   uint32(2),
@@ -2045,6 +2059,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 						},
 						Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 							Spec: virtv1.VirtualMachineInstanceSpec{
+								Hypervisor: "ch",
 								Domain: virtv1.DomainSpec{
 									Memory: &virtv1.Memory{
 										Guest: resource.NewQuantity(1*1024*1024*1024, resource.BinarySI),

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -245,13 +245,15 @@ var _ = SIGDescribe("Storage", func() {
 				return libvmi.New(
 					libvmi.WithPersistentVolumeClaim("disk0", claimName),
 					libvmi.WithResourceMemory("256Mi"),
-					libvmi.WithRng())
+					libvmi.WithHypervisor("ch"),
+					libvmi.WithAutoattachGraphicsDevice(false))
 			}
 			newRandomVMIWithCDRom := func(claimName string) *v1.VirtualMachineInstance {
 				return libvmi.New(
 					libvmi.WithCDRom("disk0", v1.DiskBusSATA, claimName),
 					libvmi.WithResourceMemory("256Mi"),
-					libvmi.WithRng())
+					libvmi.WithHypervisor("ch"),
+					libvmi.WithAutoattachGraphicsDevice(false))
 			}
 
 			Context("should be successfully", func() {
@@ -447,7 +449,9 @@ var _ = SIGDescribe("Storage", func() {
 
 					vmi = libvmi.New(
 						libvmi.WithResourceMemory("256Mi"),
+						libvmi.WithHypervisor("ch"),
 						libvmi.WithEphemeralPersistentVolumeClaim("disk0", pvName),
+						libvmi.WithAutoattachGraphicsDevice(false),
 					)
 
 					if storageEngine == "nfs" {
@@ -470,7 +474,9 @@ var _ = SIGDescribe("Storage", func() {
 				vmi = libvmi.New(
 					libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
 					libvmi.WithResourceMemory("256Mi"),
+					libvmi.WithHypervisor("ch"),
 					libvmi.WithEphemeralPersistentVolumeClaim("disk0", tests.DiskAlpineHostPath),
+					libvmi.WithAutoattachGraphicsDevice(false),
 				)
 
 				By("Starting the VirtualMachineInstance")
@@ -539,7 +545,8 @@ var _ = SIGDescribe("Storage", func() {
 					libvmi.WithPersistentVolumeClaim("disk0", tests.DiskAlpineHostPath),
 					libvmi.WithPersistentVolumeClaim("disk1", tests.DiskCustomHostPath),
 					libvmi.WithResourceMemory("256Mi"),
-					libvmi.WithRng())
+					libvmi.WithHypervisor("ch"),
+					libvmi.WithAutoattachGraphicsDevice(false))
 
 				num := 3
 				By("Starting and stopping the VirtualMachineInstance number of times")
@@ -575,6 +582,8 @@ var _ = SIGDescribe("Storage", func() {
 					libvmi.WithHostDisk("host-disk", "somepath", v1.HostDiskExistsOrCreate),
 					// hostdisk needs a privileged namespace
 					libvmi.WithNamespace(testsuite.NamespacePrivileged),
+					libvmi.WithHypervisor("ch"),
+					libvmi.WithAutoattachGraphicsDevice(false),
 				)
 				virtClient := kubevirt.Client()
 				_, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
@@ -631,6 +640,8 @@ var _ = SIGDescribe("Storage", func() {
 							libvmi.WithHostDisk("host-disk", diskPath, v1.HostDiskExistsOrCreate),
 							// hostdisk needs a privileged namespace
 							libvmi.WithNamespace(testsuite.NamespacePrivileged),
+							libvmi.WithHypervisor("ch"),
+							libvmi.WithAutoattachGraphicsDevice(false),
 						)
 						vmi.Spec.Domain.Devices.Disks[0].DiskDevice.Disk.Bus = driver
 
@@ -663,6 +674,8 @@ var _ = SIGDescribe("Storage", func() {
 							libvmi.WithHostDisk("anotherdisk", filepath.Join(hostDiskDir, "another.img"), v1.HostDiskExistsOrCreate),
 							// hostdisk needs a privileged namespace
 							libvmi.WithNamespace(testsuite.NamespacePrivileged),
+							libvmi.WithHypervisor("ch"),
+							libvmi.WithAutoattachGraphicsDevice(false),
 						)
 						vmi = libvmops.RunVMIAndExpectLaunch(vmi, 30)
 
@@ -718,6 +731,8 @@ var _ = SIGDescribe("Storage", func() {
 							libvmi.WithNodeAffinityFor(nodeName),
 							// hostdisk needs a privileged namespace
 							libvmi.WithNamespace(testsuite.NamespacePrivileged),
+							libvmi.WithHypervisor("ch"),
+							libvmi.WithAutoattachGraphicsDevice(false),
 						)
 						vmi = libvmops.RunVMIAndExpectLaunch(vmi, 30)
 
@@ -744,6 +759,8 @@ var _ = SIGDescribe("Storage", func() {
 							libvmi.WithNodeAffinityFor(nodeName),
 							// hostdisk needs a privileged namespace
 							libvmi.WithNamespace(testsuite.NamespacePrivileged),
+							libvmi.WithHypervisor("ch"),
+							libvmi.WithAutoattachGraphicsDevice(false),
 						)
 						for i, volume := range vmi.Spec.Volumes {
 							if volume.HostDisk != nil {
@@ -766,6 +783,8 @@ var _ = SIGDescribe("Storage", func() {
 							libvmi.WithHostDisk("host-disk", "/data/unknown.img", "unknown"),
 							// hostdisk needs a privileged namespace
 							libvmi.WithNamespace(testsuite.NamespacePrivileged),
+							libvmi.WithHypervisor("ch"),
+							libvmi.WithAutoattachGraphicsDevice(false),
 						)
 						_, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
 						Expect(err).To(HaveOccurred())
@@ -805,6 +824,8 @@ var _ = SIGDescribe("Storage", func() {
 							libvmi.WithResourceMemory("256Mi"),
 							libvmi.WithNetwork(v1.DefaultPodNetwork()),
 							libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+							libvmi.WithHypervisor("ch"),
+							libvmi.WithAutoattachGraphicsDevice(false),
 							libvmi.WithNodeSelectorFor(&k8sv1.Node{ObjectMeta: metav1.ObjectMeta{Name: node}}))
 						vmi = libvmops.RunVMIAndExpectLaunch(vmi, 90)
 
@@ -897,6 +918,8 @@ var _ = SIGDescribe("Storage", func() {
 						libvmi.WithNodeAffinityFor(pod.Spec.NodeName),
 						// hostdisk needs a privileged namespace
 						libvmi.WithNamespace(testsuite.NamespacePrivileged),
+						libvmi.WithHypervisor("ch"),
+						libvmi.WithAutoattachGraphicsDevice(false),
 					)
 					vmi.Spec.Volumes[0].HostDisk.Capacity = resource.MustParse(strconv.Itoa(int(float64(diskSize) * 1.2)))
 					vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
@@ -924,6 +947,8 @@ var _ = SIGDescribe("Storage", func() {
 						libvmi.WithNodeAffinityFor(pod.Spec.NodeName),
 						// hostdisk needs a privileged namespace
 						libvmi.WithNamespace(testsuite.NamespacePrivileged),
+						libvmi.WithHypervisor("ch"),
+						libvmi.WithAutoattachGraphicsDevice(false),
 					)
 					vmi.Spec.Volumes[0].HostDisk.Capacity = resource.MustParse(strconv.Itoa(int(float64(diskSize) * 1.2)))
 					libvmops.RunVMIAndExpectLaunch(vmi, 30)
@@ -971,6 +996,8 @@ var _ = SIGDescribe("Storage", func() {
 					libvmi.WithResourceMemory("256Mi"),
 					libvmi.WithPersistentVolumeClaim("disk0", dataVolume.Name),
 					libvmi.WithCloudInitNoCloud(libvmifact.WithDummyCloudForFastBoot()),
+					libvmi.WithHypervisor("ch"),
+					libvmi.WithAutoattachGraphicsDevice(false),
 				)
 				vmi = libvmops.RunVMIAndExpectLaunch(vmi, 90)
 
@@ -1017,6 +1044,8 @@ var _ = SIGDescribe("Storage", func() {
 				vmi = libvmi.New(
 					libvmi.WithResourceMemory("128Mi"),
 					libvmi.WithPersistentVolumeClaim("disk0", pvcName),
+					libvmi.WithHypervisor("ch"),
+					libvmi.WithAutoattachGraphicsDevice(false),
 				)
 				vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -1211,6 +1240,8 @@ var _ = SIGDescribe("Storage", func() {
 					libvmi.WithDataVolume("disk0", dv.Name),
 					libvmi.WithResourceMemory("1Gi"),
 					libvmi.WithLabel(labelKey, ""),
+					libvmi.WithHypervisor("ch"),
+					libvmi.WithAutoattachGraphicsDevice(false),
 				)
 				vmi2 = libvmi.New(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
@@ -1218,6 +1249,8 @@ var _ = SIGDescribe("Storage", func() {
 					libvmi.WithDataVolume("disk0", dv.Name),
 					libvmi.WithResourceMemory("1Gi"),
 					libvmi.WithLabel(labelKey, ""),
+					libvmi.WithHypervisor("ch"),
+					libvmi.WithAutoattachGraphicsDevice(false),
 				)
 
 				vmi1.Spec.Affinity = affinityRule


### PR DESCRIPTION
### What this PR does
Before this PR:

Some of KubeVirt's test cases were creating VMIs with the RNG device and were not passing the vmi.spec.hypervisor field. This works for vanilla KubeVirt running on QEMU/KVM, because (1) vanilla kubevirt has no API ref for vmi.spec.hypervisor, and (2) QEMU can host a guest with RNG device. However, cloud-hypervisor cannot host a guest with RNG device. In this version of KubeVirt, we need to explicitly specify the virt-stack to be used for the VM via the vmi.spec.hypervisor field.

After this PR:
The tests that were failing due to either missing vmi.spec.hypervisor field or due to the presence of RNG device no longer fail due to the same reason.
