### PR TITLE
Set virtio as console target type

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1788,20 +1788,17 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		})
 
 		var serialPort uint = 0
+		var virtioType string = "virtio"
 
-		/* Cloud-Hypervisor does not support serial console
-		Tracked by this bug: https://dev.azure.com/mariner-org/ECF/_workitems/edit/9044
-
-		var serialType string = "serial"
 		domain.Spec.Devices.Consoles = []api.Console{
 			{
 				Type: "pty",
 				Target: &api.ConsoleTarget{
-					Type: &serialType,
+					Type: &virtioType,
 					Port: &serialPort,
 				},
 			},
-		}*/
+		}
 
 		socketPath := fmt.Sprintf("%s/%s/virt-serial%d", util.VirtPrivateDir, vmi.ObjectMeta.UID, serialPort)
 		domain.Spec.Devices.Serials = []api.Serial{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:
KubeVirt automatically creates a console device for each VMI with target type "serial" - which implies that this console device will not be an independent device, rather it will simply be a copy of the first serial device (https://libvirt.org/formatdomain.html#console). Thus, the config of the serial device was copied to this console device. The serial device was of type Unix - but cloud-hypervisor does not support a console device of type Unix. Thus VM creation used to fail. That is why, we had commented out the creation of a console device in the VMI. 

After this PR: Now, a VMI can be created and will get both a console device and a serial device. Two ways of connecting to the VM have been tested to work:
- `virsh console <vm>`
- `kubectl exec <virt_launcher_pod> -- virsh console <ns>_<vm>`
