### PR TITLE
Remove RAW cloud-init generation code

### DIFF
--- a/pkg/cloud-init/BUILD.bazel
+++ b/pkg/cloud-init/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ephemeral-disk-utils:go_default_library",
-        "//pkg/hypervisor:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/net/dns:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/hypervisor/hypervisor.go
+++ b/pkg/hypervisor/hypervisor.go
@@ -193,7 +193,7 @@ func (c *CloudHypervisor) GetHypervisorOverhead() string {
 }
 
 func (c *CloudHypervisor) SupportsIso() bool {
-	return false
+	return true
 }
 
 // Implement GetDefaultKernelPath method for CloudHypervisor

--- a/pkg/hypervisor/hypervisor.go
+++ b/pkg/hypervisor/hypervisor.go
@@ -23,9 +23,6 @@ type Hypervisor interface {
 	// The `ps` RSS for vmm, minus the RAM of its (stressed) guest, minus the virtual page table
 	GetHypervisorOverhead() string
 
-	// Return true if the hypervisor supports ISO files
-	SupportsIso() bool
-
 	// Return the K8s device name that should be exposed for the hypervisor,
 	// e.g., devices.kubevirt.io/kvm for QEMU and devices.kubevirt.io/mshv for Cloud Hypervisor
 	GetHypervisorDevice() string
@@ -122,10 +119,6 @@ func (q *QemuHypervisor) GetHypervisorOverhead() string {
 	return "30Mi"
 }
 
-func (q *QemuHypervisor) SupportsIso() bool {
-	return true
-}
-
 // Implement GetDefaultKernelPath method for QemuHypervisor
 func (q *QemuHypervisor) GetDefaultKernelPath() (string, string) {
 	return "", ""
@@ -190,10 +183,6 @@ func (c *CloudHypervisor) GetHypervisorDaemonOverhead() string {
 // Implement GetHypervisorOverhead method for CloudHypervisor
 func (c *CloudHypervisor) GetHypervisorOverhead() string {
 	return "30Mi"
-}
-
-func (c *CloudHypervisor) SupportsIso() bool {
-	return true
 }
 
 // Implement GetDefaultKernelPath method for CloudHypervisor

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1297,15 +1297,10 @@ func (d *VirtualMachineController) updateFSFreezeStatus(vmi *v1.VirtualMachineIn
 }
 
 func IsoGuestVolumePath(vmi *v1.VirtualMachineInstance, namespace, name string, volume *v1.Volume) string {
-	hypervisor := hypervisor.NewHypervisor(vmi.Spec.Hypervisor)
 	const basepath = "/var/run"
 	switch {
 	case volume.CloudInitNoCloud != nil:
-		if hypervisor.SupportsIso() {
-			return filepath.Join(basepath, "kubevirt-ephemeral-disks", "cloud-init-data", namespace, name, "noCloud.iso")
-		} else {
-			return filepath.Join(basepath, "kubevirt-ephemeral-disks", "cloud-init-data", vmi.Namespace, vmi.Name, "noCloud.img")
-		}
+		return filepath.Join(basepath, "kubevirt-ephemeral-disks", "cloud-init-data", namespace, name, "noCloud.iso")
 	case volume.CloudInitConfigDrive != nil:
 		return filepath.Join(basepath, "kubevirt-ephemeral-disks", "cloud-init-data", namespace, name, "configdrive.iso")
 	case volume.ConfigMap != nil:

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -801,7 +801,7 @@ func Convert_v1_CloudInitSource_To_api_Disk(source v1.VolumeSource, disk *api.Di
 		return fmt.Errorf("Only nocloud and configdrive are valid cloud-init volumes")
 	}
 
-	disk.Source.File = cloudinit.GetCloudInitFilePath(dataSource, c.VirtualMachine.Name, c.VirtualMachine.Namespace, c.Hypervisor)
+	disk.Source.File = cloudinit.GetIsoFilePath(dataSource, c.VirtualMachine.Name, c.VirtualMachine.Namespace)
 	disk.Type = "file"
 	disk.Driver.Type = "raw"
 	disk.Driver.ErrorPolicy = v1.DiskErrorPolicyStop

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -672,12 +672,9 @@ func (l *LibvirtDomainManager) generateSomeCloudInitISO(vmi *v1.VirtualMachineIn
 			cloudInitDataStore.DevicesData = &devicesMetadata
 		}
 
-		// Instantiate Hypervisor interface
-		hypervisor := hypervisor.NewHypervisor(vmi.Spec.Hypervisor)
-
 		var err error
 		if size != 0 {
-			err = cloudinit.GenerateEmptyIso(vmi.Name, vmi.Namespace, cloudInitDataStore, size, hypervisor)
+			err = cloudinit.GenerateEmptyIso(vmi.Name, vmi.Namespace, cloudInitDataStore, size)
 		} else {
 			// ClusterInstancetype will take precedence over a namespaced Instancetype
 			// for setting instance_type in the metadata
@@ -686,7 +683,7 @@ func (l *LibvirtDomainManager) generateSomeCloudInitISO(vmi *v1.VirtualMachineIn
 				instancetype = vmi.Annotations[v1.InstancetypeAnnotation]
 			}
 
-			err = cloudinit.GenerateLocalData(vmi, instancetype, cloudInitDataStore, hypervisor)
+			err = cloudinit.GenerateLocalData(vmi, instancetype, cloudInitDataStore)
 		}
 		if err != nil {
 			return fmt.Errorf("generating local cloud-init data failed: %v", err)

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 	"time"
 
-	"kubevirt.io/kubevirt/pkg/hypervisor"
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	"kubevirt.io/kubevirt/pkg/pointer"
@@ -124,7 +123,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		pod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
 		Expect(err).NotTo(HaveOccurred())
 
-		path := cloudinit.GetCloudInitFilePath(source, vmi.Name, vmi.Namespace, hypervisor.NewHypervisor(vmi.Spec.Hypervisor))
+		path := cloudinit.GetIsoFilePath(source, vmi.Name, vmi.Namespace)
 
 		By(fmt.Sprintf("Checking cloud init ISO at '%s' is 4k-block fs compatible", path))
 		cmdCheck := []string{"stat", "--printf='%s'", path}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR: For Cloud-Hypervisor based VMIs with cloud-init configuration in VMI spec, the CloudInit drive was created as a RAW disk and attached to the VM. This was done because (at the time) Cloud Hypervisor didn't support attaching ISO devices to VMs.

After this PR: Now that Cloud-Hypervisor does support attaching ISO devices to VMs, this PR removes the RAW cloud-init generation code and uses the ISO generation code instead. 

### Testing
- Local testing on baremetal cluster
- Automated testing on mshv-dom0-baremetal-tests pipeline
