### PR TITLE
Set VMI domain type from Hypervisor interface

### DIFF
--- a/pkg/hypervisor/hypervisor.go
+++ b/pkg/hypervisor/hypervisor.go
@@ -48,6 +48,9 @@ type Hypervisor interface {
 	// Return the default kernel path and initrd path for the hypervisor
 	// If default kernel is not needed return "", ""
 	GetDefaultKernelPath() (string, string)
+
+	// Return the domain type in Libvirt domain XML
+	GetDomainType() string
 }
 
 // Define QemuHypervisor struct that implements the Hypervisor interface
@@ -55,6 +58,11 @@ type QemuHypervisor struct {
 }
 
 type CloudHypervisor struct {
+}
+
+// Implement GetDomainType method for QemuHypervisor
+func (q *QemuHypervisor) GetDomainType() string {
+	return "kvm"
 }
 
 // Implement SupportsMemoryBallooning method for QemuHypervisor
@@ -188,6 +196,11 @@ func (c *CloudHypervisor) GetHypervisorOverhead() string {
 // Implement GetDefaultKernelPath method for CloudHypervisor
 func (c *CloudHypervisor) GetDefaultKernelPath() (string, string) {
 	return "/usr/share/cloud-hypervisor/CLOUDHV_EFI.fd", ""
+}
+
+// Implement GetDomainType method for CloudHypervisor
+func (c *CloudHypervisor) GetDomainType() string {
+	return "hyperv"
 }
 
 func NewHypervisor(hypervisor string) Hypervisor {

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1322,7 +1322,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	hypervisorKubeVirtDevice := strings.TrimPrefix(c.Hypervisor.GetHypervisorDevice(), "devices.kubevirt.io/")
 	hypervisorPath := fmt.Sprintf("/dev/%s", hypervisorKubeVirtDevice)
 
-	domain.Spec.Type = "hyperv" // TODO Refactor to use hypervisor type from hypervisor
+	domain.Spec.Type = c.Hypervisor.GetDomainType()
 
 	if softwareEmulation, err := util.UseSoftwareEmulationForDevice(hypervisorPath, c.AllowEmulation); err != nil {
 		return err


### PR DESCRIPTION
### What this PR does
Before this PR: Domain type was hardcoded to `hyperv`. Which meant that this fork of KubeVirt could only produce QEMU VMs.

After this PR: Domain type is not based on the `spec.hypervisor` field of the VMI. So based on the user's VMI request, the appropriate domain type will be set.