### PR TITLE
Set DomainType from Hypervisor interface

### DIFF
--- a/pkg/hypervisor/hypervisor.go
+++ b/pkg/hypervisor/hypervisor.go
@@ -49,8 +49,8 @@ type Hypervisor interface {
 	// If default kernel is not needed return "", ""
 	GetDefaultKernelPath() (string, string)
 
-  // Get the domain type for Libvirt domain XML
-  GetDomainType() string
+	// Get the domain type for Libvirt domain XML
+	GetDomainType() string
 }
 
 // Define QemuHypervisor struct that implements the Hypervisor interface
@@ -76,7 +76,7 @@ func (q *QemuHypervisor) GetDiskDriver() string {
 }
 
 func (q *QemuHypervisor) GetDomainType() string {
-  return "kvm"
+	return "kvm"
 }
 
 // Implement GetLibvirtSocketPath method for QemuHypervisor
@@ -198,7 +198,7 @@ func (c *CloudHypervisor) GetDefaultKernelPath() (string, string) {
 }
 
 func (c *CloudHypervisor) GetDomainType() string {
-  return "hyperv"
+	return "hyperv"
 }
 
 func NewHypervisor(hypervisor string) Hypervisor {

--- a/pkg/hypervisor/hypervisor.go
+++ b/pkg/hypervisor/hypervisor.go
@@ -48,6 +48,9 @@ type Hypervisor interface {
 	// Return the default kernel path and initrd path for the hypervisor
 	// If default kernel is not needed return "", ""
 	GetDefaultKernelPath() (string, string)
+
+  // Get the domain type for Libvirt domain XML
+  GetDomainType() string
 }
 
 // Define QemuHypervisor struct that implements the Hypervisor interface
@@ -70,6 +73,10 @@ func (q *QemuHypervisor) RequiresBootOrder() bool {
 // Implement GetDiskDriver method for QemuHypervisor
 func (q *QemuHypervisor) GetDiskDriver() string {
 	return "qemu"
+}
+
+func (q *QemuHypervisor) GetDomainType() string {
+  return "kvm"
 }
 
 // Implement GetLibvirtSocketPath method for QemuHypervisor
@@ -188,6 +195,10 @@ func (c *CloudHypervisor) GetHypervisorOverhead() string {
 // Implement GetDefaultKernelPath method for CloudHypervisor
 func (c *CloudHypervisor) GetDefaultKernelPath() (string, string) {
 	return "/usr/share/cloud-hypervisor/CLOUDHV_EFI.fd", ""
+}
+
+func (c *CloudHypervisor) GetDomainType() string {
+  return "hyperv"
 }
 
 func NewHypervisor(hypervisor string) Hypervisor {

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1322,7 +1322,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	hypervisorKubeVirtDevice := strings.TrimPrefix(c.Hypervisor.GetHypervisorDevice(), "devices.kubevirt.io/")
 	hypervisorPath := fmt.Sprintf("/dev/%s", hypervisorKubeVirtDevice)
 
-	domain.Spec.Type = "hyperv" // TODO Refactor to use hypervisor type from hypervisor
+	domain.Spec.Type = c.Hypervisor.GetDomainType()
 
 	if softwareEmulation, err := util.UseSoftwareEmulationForDevice(hypervisorPath, c.AllowEmulation); err != nil {
 		return err

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -348,7 +348,9 @@ func startModularLibvirtDaemon(l LibvirtWrapper, stopChan chan struct{}) {
 
 			go func() {
 				defer close(exitChan)
-				cmd.Wait()
+				if err := cmd.Wait(); err != nil {
+					log.Log.Reason(err).Error("libvirt daemon process exited with error")
+				}
 			}()
 
 			select {


### PR DESCRIPTION
This PR introduces the `GetDomainType` method to the `Hypervisor` interface.

### What this PR does
Before this PR: The domain type for libvirt VM was hardcoded to "hyperv"

After this PR: The domain type for libvirt VM is retrieved from the `Hypervisor` interface based on the `hypervisor` field in the VMI spec.
