### PR TITLE
Make "qemu" the default hypervisor type

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -17187,7 +17187,7 @@
       "type": "string"
      },
      "hypervisor": {
-      "description": "The Hypervisor to use for the VMI. Possible values are \"qemu\" for QEMU and \"ch\" for Cloud Hypervisor.",
+      "description": "The Hypervisor to use for the VMI. Possible values are \"qemu\" for QEMU and \"ch\" for Cloud Hypervisor. Default value is \"qemu\".",
       "type": "string"
      },
      "livenessProbe": {

--- a/pkg/hypervisor/hypervisor.go
+++ b/pkg/hypervisor/hypervisor.go
@@ -21,6 +21,11 @@ import (
 )
 
 const (
+	QemuHypervisorKey  string = "qemu"
+	CloudHypervisorKey string = "ch"
+)
+
+const (
 	vmmConfPathPattern              = "/etc/libvirt/%s.conf"
 	vmmModularDaemonConfPathPattern = "/etc/libvirt/%s.conf"
 	libvirtRuntimePath              = "/var/run/libvirt"
@@ -104,7 +109,7 @@ func NewHypervisor(hypervisor string) Hypervisor {
 }
 
 func NewHypervisorWithUser(hypervisor string, nonRoot bool) Hypervisor {
-	if hypervisor == "qemu" {
+	if hypervisor == QemuHypervisorKey {
 		if nonRoot {
 			return &QemuHypervisor{
 				user: util.NonRootUID,
@@ -113,7 +118,7 @@ func NewHypervisorWithUser(hypervisor string, nonRoot bool) Hypervisor {
 		return &QemuHypervisor{
 			user: util.RootUser,
 		}
-	} else if hypervisor == "ch" {
+	} else if hypervisor == CloudHypervisorKey {
 		return &CloudHypervisor{util.RootUser}
 	} else {
 		return nil

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -7016,7 +7016,8 @@ var CRDsValidation map[string]string = map[string]string{
                   type: string
                 hypervisor:
                   description: The Hypervisor to use for the VMI. Possible values
-                    are "qemu" for QEMU and "ch" for Cloud Hypervisor.
+                    are "qemu" for QEMU and "ch" for Cloud Hypervisor. Default value
+                    is "qemu".
                   type: string
                 livenessProbe:
                   description: |-
@@ -12069,7 +12070,7 @@ var CRDsValidation map[string]string = map[string]string{
           type: string
         hypervisor:
           description: The Hypervisor to use for the VMI. Possible values are "qemu"
-            for QEMU and "ch" for Cloud Hypervisor.
+            for QEMU and "ch" for Cloud Hypervisor. Default value is "qemu".
           type: string
         livenessProbe:
           description: |-
@@ -17629,7 +17630,8 @@ var CRDsValidation map[string]string = map[string]string{
                   type: string
                 hypervisor:
                   description: The Hypervisor to use for the VMI. Possible values
-                    are "qemu" for QEMU and "ch" for Cloud Hypervisor.
+                    are "qemu" for QEMU and "ch" for Cloud Hypervisor. Default value
+                    is "qemu".
                   type: string
                 livenessProbe:
                   description: |-
@@ -22138,6 +22140,7 @@ var CRDsValidation map[string]string = map[string]string{
                         hypervisor:
                           description: The Hypervisor to use for the VMI. Possible
                             values are "qemu" for QEMU and "ch" for Cloud Hypervisor.
+                            Default value is "qemu".
                           type: string
                         livenessProbe:
                           description: |-
@@ -27313,6 +27316,7 @@ var CRDsValidation map[string]string = map[string]string{
                             hypervisor:
                               description: The Hypervisor to use for the VMI. Possible
                                 values are "qemu" for QEMU and "ch" for Cloud Hypervisor.
+                                Default value is "qemu".
                               type: string
                             livenessProbe:
                               description: |-

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -74,12 +74,13 @@ type StartStrategy string
 
 const (
 	StartStrategyPaused StartStrategy = "Paused"
+	QemuHypervisor      string        = "qemu"
 )
 
 // VirtualMachineInstanceSpec is a description of a VirtualMachineInstance.
 type VirtualMachineInstanceSpec struct {
 
-	// The Hypervisor to use for the VMI. Possible values are "qemu" for QEMU and "ch" for Cloud Hypervisor.
+	// The Hypervisor to use for the VMI. Possible values are "qemu" for QEMU and "ch" for Cloud Hypervisor. Default value is "qemu".
 	Hypervisor string `json:"hypervisor,omitempty"`
 
 	// If specified, indicates the pod's priority.
@@ -181,6 +182,10 @@ func (vmiSpec *VirtualMachineInstanceSpec) UnmarshalJSON(data []byte) error {
 
 	if err := json.Unmarshal(data, &vmiSpecAlias); err != nil {
 		return err
+	}
+
+	if vmiSpecAlias.Hypervisor == "" {
+		vmiSpecAlias.Hypervisor = QemuHypervisor
 	}
 
 	if vmiSpecAlias.DNSConfig != nil {

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -19,7 +19,7 @@ func (VirtualMachineInstanceList) SwaggerDoc() map[string]string {
 func (VirtualMachineInstanceSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                              "VirtualMachineInstanceSpec is a description of a VirtualMachineInstance.",
-		"hypervisor":                    "The Hypervisor to use for the VMI. Possible values are \"qemu\" for QEMU and \"ch\" for Cloud Hypervisor.",
+		"hypervisor":                    "The Hypervisor to use for the VMI. Possible values are \"qemu\" for QEMU and \"ch\" for Cloud Hypervisor. Default value is \"qemu\".",
 		"priorityClassName":             "If specified, indicates the pod's priority.\nIf not specified, the pod priority will be default or zero if there is no\ndefault.\n+optional",
 		"domain":                        "Specification of the desired behavior of the VirtualMachineInstance on the host.",
 		"nodeSelector":                  "NodeSelector is a selector which must be true for the vmi to fit on a node.\nSelector which must match a node's labels for the vmi to be scheduled on that node.\nMore info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/\n+optional",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -25522,7 +25522,7 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceSpec(ref common.Referen
 				Properties: map[string]spec.Schema{
 					"hypervisor": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The Hypervisor to use for the VMI. Possible values are \"qemu\" for QEMU and \"ch\" for Cloud Hypervisor.",
+							Description: "The Hypervisor to use for the VMI. Possible values are \"qemu\" for QEMU and \"ch\" for Cloud Hypervisor. Default value is \"qemu\".",
 							Type:        []string{"string"},
 							Format:      "",
 						},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before this PR:

After this PR:

<!-- (optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: -->
Fixes #

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

