### PR TITLE
Quarantine the flaky TPM tests

### DIFF
--- a/tests/vm_state_test.go
+++ b/tests/vm_state_test.go
@@ -113,7 +113,9 @@ var _ = Describe("[sig-compute]VM state", func() {
 			}, 10)).To(Succeed(), "expected efivar is missing")
 		}
 
-		DescribeTable("should persist VM state of", decorators.RequiresTwoSchedulableNodes, func(withTPM, withEFI, shouldBeRWX bool, ops ...string) {
+		// Quarantining this test due to repeated flaky failures in Azure DevOps pipeline.
+		// Remove Quarantine decorator once bug has been resolved: https://dev.azure.com/mariner-org/ECF/_workitems/edit/12432
+		DescribeTable("[QUARANTINE] should persist VM state of", decorators.Quarantine, decorators.RequiresTwoSchedulableNodes, func(withTPM, withEFI, shouldBeRWX bool, ops ...string) {
 			By("Creating a migratable Fedora VM with UEFI")
 			vmi := libvmifact.NewFedora(
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),


### PR DESCRIPTION
### What this PR does
Before this PR: sig-compute test suite had intermittent failures in the TPM-related tests.

After this PR: Flaky TPM-related tests are skipped and sig-compute test suite passes consistently.

Links to places where the discussion took place: https://dev.azure.com/mariner-org/ECF/_workitems/edit/12432/

