### PR TITLE
Move common agent-execution data types to a separate file

### DIFF
--- a/pkg/virt-launcher/virtwrap/agent/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/agent/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["exec.go"],
+    srcs = [
+        "exec.go",
+        "types.go",
+    ],
     importpath = "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/agent",
     visibility = ["//visibility:public"],
     deps = ["//pkg/virt-launcher/virtwrap/cli:go_default_library"],

--- a/pkg/virt-launcher/virtwrap/agent/exec.go
+++ b/pkg/virt-launcher/virtwrap/agent/exec.go
@@ -9,31 +9,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"
 )
 
-type execReturn struct {
-	Return execReturnData `json:"return"`
-}
-type execReturnData struct {
-	Pid int `json:"pid"`
-}
-
-type execStatusReturn struct {
-	Return execStatusReturnData `json:"return"`
-}
-type execStatusReturnData struct {
-	Exited   bool   `json:"exited"`
-	ExitCode int    `json:"exitcode"`
-	OutData  string `json:"out-data"`
-}
-
-// ExecExitCode returned at non-zero return codes
-type ExecExitCode struct {
-	ExitCode int
-}
-
-func (e ExecExitCode) Error() string {
-	return fmt.Sprint("exited with error code:", e.ExitCode)
-}
-
 // GuestExec sends the provided command and args to the guest agent for execution and returns an error on an unsucessful exit code
 // The resulting stdout will be returned as a string
 func GuestExec(virConn cli.Connection, domName string, command string, args []string, timeoutSeconds int32) (string, error) {

--- a/pkg/virt-launcher/virtwrap/agent/types.go
+++ b/pkg/virt-launcher/virtwrap/agent/types.go
@@ -1,0 +1,28 @@
+package agent
+
+import "fmt"
+
+type execReturn struct {
+	Return execReturnData `json:"return"`
+}
+type execReturnData struct {
+	Pid int `json:"pid"`
+}
+
+type execStatusReturn struct {
+	Return execStatusReturnData `json:"return"`
+}
+type execStatusReturnData struct {
+	Exited   bool   `json:"exited"`
+	ExitCode int    `json:"exitcode"`
+	OutData  string `json:"out-data"`
+}
+
+// ExecExitCode returned at non-zero return codes
+type ExecExitCode struct {
+	ExitCode int
+}
+
+func (e ExecExitCode) Error() string {
+	return fmt.Sprint("exited with error code:", e.ExitCode)
+}


### PR DESCRIPTION
### What this PR does
Before this PR: Data types utilized for executing commands in the guest via Guest Agent were present in the same file as the GuestExec function - that invokes the QEMUGuestAgent. 

After this PR: The data types are moved to a separate file, `types.go`, to improve code organization and maintainability.

### Testing done

- `make bazel-build-images` and `make bazel-build-functests` succeed.
- Running `sig-compute` functional tests: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=833462&view=results