### PR TITLE
Introduce FormatError as a fn. in DomainManager interface

### DIFF
--- a/pkg/virt-launcher/virtwrap/cmd-server/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/cmd-server/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-launcher/virtwrap:go_default_library",
         "//pkg/virt-launcher/virtwrap/agent:go_default_library",
-        "//pkg/virt-launcher/virtwrap/errors:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",

--- a/pkg/virt-launcher/virtwrap/cmd-server/server.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server.go
@@ -38,7 +38,6 @@ import (
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/agent"
-	launcherErrors "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/errors"
 )
 
 const (
@@ -87,11 +86,11 @@ func getMigrationOptionsFromRequest(request *cmdv1.MigrationRequest) (*cmdclient
 	return options, nil
 }
 
-func getErrorMessage(err error) string {
-	if virErr := launcherErrors.FormatLibvirtError(err); virErr != "" {
-		return virErr
-	}
-	return err.Error()
+func (l *Launcher) formatError(err error) string {
+	// Call the DomainManager implementation's FormatError fn to
+	// return an error string formatted appropriately for the impl's
+	// target virtualization stack.
+	return l.domainManager.FormatError(err)
 }
 
 func (l *Launcher) MigrateVirtualMachine(_ context.Context, request *cmdv1.MigrationRequest) (*cmdv1.Response, error) {
@@ -111,7 +110,7 @@ func (l *Launcher) MigrateVirtualMachine(_ context.Context, request *cmdv1.Migra
 	if err := l.domainManager.MigrateVMI(vmi, options); err != nil {
 		log.Log.Object(vmi).Reason(err).Errorf("Failed to migrate vmi")
 		response.Success = false
-		response.Message = getErrorMessage(err)
+		response.Message = l.formatError(err)
 		return response, nil
 	}
 
@@ -129,7 +128,7 @@ func (l *Launcher) CancelVirtualMachineMigration(_ context.Context, request *cmd
 	if err := l.domainManager.CancelVMIMigration(vmi); err != nil {
 		log.Log.Object(vmi).Reason(err).Errorf("Failed to abort live migration")
 		response.Success = false
-		response.Message = getErrorMessage(err)
+		response.Message = l.formatError(err)
 		return response, nil
 	}
 
@@ -165,7 +164,7 @@ func (l *Launcher) SyncMigrationTarget(_ context.Context, request *cmdv1.VMIRequ
 	if err := l.domainManager.PrepareMigrationTarget(vmi, l.allowEmulation, request.Options); err != nil {
 		log.Log.Object(vmi).Reason(err).Errorf("Failed to prepare migration target pod")
 		response.Success = false
-		response.Message = getErrorMessage(err)
+		response.Message = l.formatError(err)
 		return response, nil
 	}
 
@@ -183,7 +182,7 @@ func (l *Launcher) SyncVirtualMachineCPUs(_ context.Context, request *cmdv1.VMIR
 	if err := l.domainManager.UpdateVCPUs(vmi, request.Options); err != nil {
 		log.Log.Object(vmi).Reason(err).Errorf("Failed update VMI vCPUs")
 		response.Success = false
-		response.Message = getErrorMessage(err)
+		response.Message = l.formatError(err)
 		return response, nil
 	}
 
@@ -201,7 +200,7 @@ func (l *Launcher) SyncVirtualMachine(_ context.Context, request *cmdv1.VMIReque
 	if _, err := l.domainManager.SyncVMI(vmi, l.allowEmulation, request.Options); err != nil {
 		log.Log.Object(vmi).Reason(err).Errorf("Failed to sync vmi")
 		response.Success = false
-		response.Message = getErrorMessage(err)
+		response.Message = l.formatError(err)
 		return response, nil
 	}
 
@@ -218,7 +217,7 @@ func (l *Launcher) PauseVirtualMachine(_ context.Context, request *cmdv1.VMIRequ
 	if err := l.domainManager.PauseVMI(vmi); err != nil {
 		log.Log.Object(vmi).Reason(err).Errorf("Failed to pause vmi")
 		response.Success = false
-		response.Message = getErrorMessage(err)
+		response.Message = l.formatError(err)
 		return response, nil
 	}
 
@@ -235,7 +234,7 @@ func (l *Launcher) UnpauseVirtualMachine(_ context.Context, request *cmdv1.VMIRe
 	if err := l.domainManager.UnpauseVMI(vmi); err != nil {
 		log.Log.Object(vmi).Reason(err).Errorf("Failed to unpause vmi")
 		response.Success = false
-		response.Message = getErrorMessage(err)
+		response.Message = l.formatError(err)
 		return response, nil
 	}
 
@@ -252,7 +251,7 @@ func (l *Launcher) VirtualMachineMemoryDump(_ context.Context, request *cmdv1.Me
 	if err := l.domainManager.MemoryDump(vmi, request.DumpPath); err != nil {
 		log.Log.Object(vmi).Reason(err).Errorf("Failed to Dump vmi memory")
 		response.Success = false
-		response.Message = getErrorMessage(err)
+		response.Message = l.formatError(err)
 		return response, nil
 	}
 
@@ -268,7 +267,7 @@ func (l *Launcher) FreezeVirtualMachine(_ context.Context, request *cmdv1.Freeze
 	if err := l.domainManager.FreezeVMI(vmi, request.UnfreezeTimeoutSeconds); err != nil {
 		log.Log.Object(vmi).Reason(err).Errorf("Failed to freeze vmi")
 		response.Success = false
-		response.Message = getErrorMessage(err)
+		response.Message = l.formatError(err)
 		return response, nil
 	}
 
@@ -285,7 +284,7 @@ func (l *Launcher) UnfreezeVirtualMachine(_ context.Context, request *cmdv1.VMIR
 	if err := l.domainManager.UnfreezeVMI(vmi); err != nil {
 		log.Log.Object(vmi).Reason(err).Errorf("Failed to unfreeze vmi")
 		response.Success = false
-		response.Message = getErrorMessage(err)
+		response.Message = l.formatError(err)
 		return response, nil
 	}
 
@@ -302,7 +301,7 @@ func (l *Launcher) ResetVirtualMachine(_ context.Context, request *cmdv1.VMIRequ
 	if err := l.domainManager.ResetVMI(vmi); err != nil {
 		log.Log.Object(vmi).Reason(err).Errorf("Failed to reset vmi")
 		response.Success = false
-		response.Message = getErrorMessage(err)
+		response.Message = l.formatError(err)
 		return response, nil
 	}
 
@@ -319,7 +318,7 @@ func (l *Launcher) SoftRebootVirtualMachine(_ context.Context, request *cmdv1.VM
 	if err := l.domainManager.SoftRebootVMI(vmi); err != nil {
 		log.Log.Object(vmi).Reason(err).Errorf("Failed to soft reboot vmi")
 		response.Success = false
-		response.Message = getErrorMessage(err)
+		response.Message = l.formatError(err)
 		return response, nil
 	}
 
@@ -337,7 +336,7 @@ func (l *Launcher) KillVirtualMachine(_ context.Context, request *cmdv1.VMIReque
 	if err := l.domainManager.KillVMI(vmi); err != nil {
 		log.Log.Object(vmi).Reason(err).Errorf("Failed to kill vmi")
 		response.Success = false
-		response.Message = getErrorMessage(err)
+		response.Message = l.formatError(err)
 		return response, nil
 	}
 
@@ -355,7 +354,7 @@ func (l *Launcher) ShutdownVirtualMachine(_ context.Context, request *cmdv1.VMIR
 	if err := l.domainManager.SignalShutdownVMI(vmi); err != nil {
 		log.Log.Object(vmi).Reason(err).Errorf("Failed to signal shutdown for vmi")
 		response.Success = false
-		response.Message = getErrorMessage(err)
+		response.Message = l.formatError(err)
 		return response, nil
 	}
 
@@ -373,7 +372,7 @@ func (l *Launcher) DeleteVirtualMachine(_ context.Context, request *cmdv1.VMIReq
 	if err := l.domainManager.DeleteVMI(vmi); err != nil {
 		log.Log.Object(vmi).Reason(err).Errorf("Failed to signal deletion for vmi")
 		response.Success = false
-		response.Message = getErrorMessage(err)
+		response.Message = l.formatError(err)
 		return response, nil
 	}
 
@@ -390,7 +389,7 @@ func (l *Launcher) FinalizeVirtualMachineMigration(_ context.Context, request *c
 	if err := l.domainManager.FinalizeVirtualMachineMigration(vmi, request.Options); err != nil {
 		log.Log.Object(vmi).Reason(err).Errorf("failed to finalize migration")
 		response.Success = false
-		response.Message = getErrorMessage(err)
+		response.Message = l.formatError(err)
 		return response, nil
 	}
 
@@ -407,7 +406,7 @@ func (l *Launcher) HotplugHostDevices(_ context.Context, request *cmdv1.VMIReque
 	if err := l.domainManager.HotplugHostDevices(vmi); err != nil {
 		log.Log.Object(vmi).Errorf(err.Error())
 		response.Success = false
-		response.Message = getErrorMessage(err)
+		response.Message = l.formatError(err)
 		return response, nil
 	}
 
@@ -425,7 +424,7 @@ func (l *Launcher) GetDomain(_ context.Context, _ *cmdv1.EmptyRequest) (*cmdv1.D
 	list, err := l.domainManager.ListAllDomains()
 	if err != nil {
 		response.Response.Success = false
-		response.Response.Message = getErrorMessage(err)
+		response.Response.Message = l.formatError(err)
 		return response, nil
 	}
 
@@ -440,7 +439,7 @@ func (l *Launcher) GetDomain(_ context.Context, _ *cmdv1.EmptyRequest) (*cmdv1.D
 		if domain, err := json.Marshal(domainObj); err != nil {
 			log.Log.Reason(err).Errorf("Failed to marshal domain")
 			response.Response.Success = false
-			response.Response.Message = getErrorMessage(err)
+			response.Response.Message = l.formatError(err)
 			return response, nil
 		} else {
 			response.Domain = string(domain)
@@ -456,7 +455,7 @@ func (l *Launcher) GetQemuVersion(_ context.Context, _ *cmdv1.EmptyRequest) (*cm
 	}
 
 	if version, err := l.domainManager.GetQemuVersion(); err != nil {
-		response.Response.Message = getErrorMessage(err)
+		response.Response.Message = l.formatError(err)
 	} else {
 		response.Response.Success = true
 		response.Version = version
@@ -476,14 +475,14 @@ func (l *Launcher) GetDomainStats(_ context.Context, _ *cmdv1.EmptyRequest) (*cm
 	stats, err := l.domainManager.GetDomainStats()
 	if err != nil {
 		response.Response.Success = false
-		response.Response.Message = getErrorMessage(err)
+		response.Response.Message = l.formatError(err)
 		return response, nil
 	}
 
 	if domainStats, err := json.Marshal(stats); err != nil {
 		log.Log.Reason(err).Errorf("Failed to marshal domain stats")
 		response.Response.Success = false
-		response.Response.Message = getErrorMessage(err)
+		response.Response.Message = l.formatError(err)
 	} else {
 		response.DomainStats = string(domainStats)
 	}
@@ -502,7 +501,7 @@ func (l *Launcher) GetDomainDirtyRateStats(_ context.Context, _ *cmdv1.EmptyRequ
 	stats, err := l.domainManager.GetDomainDirtyRateStats(dirtyRateCalculationTime)
 	if err != nil {
 		response.Response.Success = false
-		response.Response.Message = getErrorMessage(err)
+		response.Response.Message = l.formatError(err)
 		return response, nil
 	}
 
@@ -528,7 +527,7 @@ func (l *Launcher) GetGuestInfo(_ context.Context, _ *cmdv1.EmptyRequest) (*cmdv
 	if jGuestInfo, err := json.Marshal(guestInfo); err != nil {
 		log.Log.Reason(err).Errorf("Failed to marshal agent info")
 		response.Response.Success = false
-		response.Response.Message = getErrorMessage(err)
+		response.Response.Message = l.formatError(err)
 		return response, nil
 	} else {
 		response.GuestInfoResponse = string(jGuestInfo)
@@ -549,7 +548,7 @@ func (l *Launcher) GetUsers(_ context.Context, _ *cmdv1.EmptyRequest) (*cmdv1.Gu
 	if jUsers, err := json.Marshal(users); err != nil {
 		log.Log.Reason(err).Errorf("Failed to marshal guest user list")
 		response.Response.Success = false
-		response.Response.Message = getErrorMessage(err)
+		response.Response.Message = l.formatError(err)
 		return response, nil
 	} else {
 		response.GuestUserListResponse = string(jUsers)
@@ -570,7 +569,7 @@ func (l *Launcher) GetFilesystems(_ context.Context, _ *cmdv1.EmptyRequest) (*cm
 	if jFS, err := json.Marshal(fs); err != nil {
 		log.Log.Reason(err).Errorf("Failed to marshal guest user list")
 		response.Response.Success = false
-		response.Response.Message = getErrorMessage(err)
+		response.Response.Message = l.formatError(err)
 		return response, nil
 	} else {
 		response.GuestFilesystemsResponse = string(jFS)
@@ -691,14 +690,14 @@ func (l *Launcher) GetSEVInfo(_ context.Context, _ *cmdv1.EmptyRequest) (*cmdv1.
 	if err != nil {
 		log.Log.Reason(err).Errorf("Failed to get SEV platform info")
 		sevInfoResponse.Response.Success = false
-		sevInfoResponse.Response.Message = getErrorMessage(err)
+		sevInfoResponse.Response.Message = l.formatError(err)
 		return sevInfoResponse, nil
 	}
 
 	if sevPlatformInfoJson, err := json.Marshal(sevPlatformInfo); err != nil {
 		log.Log.Reason(err).Errorf("Failed to marshal SEV platform info")
 		sevInfoResponse.Response.Success = false
-		sevInfoResponse.Response.Message = getErrorMessage(err)
+		sevInfoResponse.Response.Message = l.formatError(err)
 		return sevInfoResponse, nil
 	} else {
 		sevInfoResponse.SevInfo = sevPlatformInfoJson
@@ -721,14 +720,14 @@ func (l *Launcher) GetLaunchMeasurement(_ context.Context, request *cmdv1.VMIReq
 	if err != nil {
 		log.Log.Object(vmi).Reason(err).Errorf("Failed to get launch measuement")
 		launchMeasurementResponse.Response.Success = false
-		launchMeasurementResponse.Response.Message = getErrorMessage(err)
+		launchMeasurementResponse.Response.Message = l.formatError(err)
 		return launchMeasurementResponse, nil
 	}
 
 	if sevMeasurementInfoJson, err := json.Marshal(sevMeasurementInfo); err != nil {
 		log.Log.Reason(err).Errorf("Failed to marshal launch measuement info")
 		launchMeasurementResponse.Response.Success = false
-		launchMeasurementResponse.Response.Message = getErrorMessage(err)
+		launchMeasurementResponse.Response.Message = l.formatError(err)
 		return launchMeasurementResponse, nil
 	} else {
 		launchMeasurementResponse.LaunchMeasurement = sevMeasurementInfoJson
@@ -753,7 +752,7 @@ func (l *Launcher) InjectLaunchSecret(_ context.Context, request *cmdv1.InjectLa
 	if err := l.domainManager.InjectLaunchSecret(vmi, &sevSecretOptions); err != nil {
 		log.Log.Object(vmi).Reason(err).Errorf("Failed to inject SEV launch secret")
 		response.Success = false
-		response.Message = getErrorMessage(err)
+		response.Message = l.formatError(err)
 		return response, nil
 	}
 
@@ -775,7 +774,7 @@ func (l *Launcher) SyncVirtualMachineMemory(_ context.Context, request *cmdv1.VM
 	if err := l.domainManager.UpdateGuestMemory(vmi); err != nil {
 		log.Log.Object(vmi).Reason(err).Errorf("Failed update VMI guest memory")
 		response.Success = false
-		response.Message = getErrorMessage(err)
+		response.Message = l.formatError(err)
 		return response, nil
 	}
 

--- a/pkg/virt-launcher/virtwrap/generated_mock_manager.go
+++ b/pkg/virt-launcher/virtwrap/generated_mock_manager.go
@@ -103,6 +103,20 @@ func (mr *MockDomainManagerMockRecorder) FinalizeVirtualMachineMigration(arg0, a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinalizeVirtualMachineMigration", reflect.TypeOf((*MockDomainManager)(nil).FinalizeVirtualMachineMigration), arg0, arg1)
 }
 
+// FormatError mocks base method.
+func (m *MockDomainManager) FormatError(err error) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FormatError", err)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// FormatError indicates an expected call of FormatError.
+func (mr *MockDomainManagerMockRecorder) FormatError(err any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FormatError", reflect.TypeOf((*MockDomainManager)(nil).FormatError), err)
+}
+
 // FreezeVMI mocks base method.
 func (m *MockDomainManager) FreezeVMI(arg0 *v1.VirtualMachineInstance, arg1 int32) error {
 	m.ctrl.T.Helper()

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -150,6 +150,7 @@ type DomainManager interface {
 	InjectLaunchSecret(*v1.VirtualMachineInstance, *v1.SEVSecretOptions) error
 	UpdateGuestMemory(vmi *v1.VirtualMachineInstance) error
 	GetDomainDirtyRateStats(calculationDuration time.Duration) (*stats.DomainStatsDirtyRate, error)
+	FormatError(err error) string
 }
 
 type LibvirtDomainManager struct {
@@ -2082,6 +2083,13 @@ func (l *LibvirtDomainManager) GetDomainDirtyRateStats(calculationDuration time.
 	}
 
 	return dirtyRateStats, nil
+}
+
+func (l *LibvirtDomainManager) FormatError(err error) string {
+	if virErr := domainerrors.FormatLibvirtError(err); virErr != "" {
+		return virErr
+	}
+	return err.Error()
 }
 
 func (l *LibvirtDomainManager) getDomainStats() ([]*stats.DomainStats, error) {


### PR DESCRIPTION
### What this PR does
Before this PR: The gRPC server in `virt-launcher` needs to format the error received from a Libvirt call before returning it as part of its response. The code that formats the error extracts key fields from the error message (e.g., Domain name, Error Code and Message), and writes them to the resultant string in a readable manner. Since the process is tied to Libvirt, it should be behind the DomainManager interface to make the gRPC server implementation agnostic of the virtualization stack.

After this PR: FormatError is a function in the DomainManager interface. That would allow the gRPC server to query formatted error from different DomainManager implementations.

Testing:

- `make bazel-build-images` and `make bazel-build-functests` run successfully.
- `sig-compute` test suite launched: https://dev.azure.com/mariner-org/ECF/_build/results?buildId=833702&view=results