### PR TITLE
Fix bad rebase in manager-libvirt.go

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager-libvirt.go
+++ b/pkg/virt-launcher/virtwrap/manager-libvirt.go
@@ -449,8 +449,8 @@ func (l *LibvirtDomainManager) UpdateVCPUs(vmi *v1.VirtualMachineInstance, optio
 
 	logger := log.Log.Object(vmi)
 
-	vcpuTopology := vcpu.GetCPUTopology(vmi)
-	vcpuCount := vcpu.CalculateRequestedVCPUs(vcpuTopology)
+	vcpuTopology := api.GetCPUTopology(vmi)
+	vcpuCount := api.CalculateRequestedVCPUs(vcpuTopology)
 	// hot plug/unplug vCPUs
 	if err := dom.SetVcpusFlags(uint(vcpuCount),
 		affectDomainVCPULiveAndConfigLibvirtFlags); err != nil {


### PR DESCRIPTION
### What this PR does
Before this PR: Compilation error due to a bad rebase in `pkg/virt-launcher/virtwrap/manager-libvirt.go`.

After this PR: Import statement has been corrected to resolve the compilation error.